### PR TITLE
Correct url in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -5,6 +5,6 @@ maintainer=Khudhur Abdullah Alfarhan <Qudoren@gmail.com>
 sentence=An Arduino library for sending and receiving data using LoRaFi board and LoRa module.
 paragraph=Supports Semtech SX1272/73 based boards/shields and LoRaFi board/shield.
 category=Communication
-url=https=//github.com/LoRaFi/LoRaFi
+url=https://github.com/LoRaFi/LoRaFi
 architectures=*
 includes=LoRaFi.h


### PR DESCRIPTION
An error in the URL caused the "More info" link in the Arduino IDE's Library Manager to not work.